### PR TITLE
Fix README datasheet link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # IS31F13743B
 
 A `#[no_std]` platform-agnostic driver for the
-[IS31F13743B](https://lumissil.com/assets/pdf/core/IS31FL3746B_DS.pdf)
+[IS31F13743B](https://lumissil.com/assets/pdf/core/IS31FL3743B_DS.pdf)
 LED matrix controller using the [embedded-hal](https://docs.rs/embedded-hal) traits.
 
 ## Usage


### PR DESCRIPTION
Datasheet linked in README is for the wrong chip. The IS31FL3746B datasheet is linked however this driver is for the IS31FL3743B.

README should be updated to the correct datasheet.