### PR TITLE
Derive Clone and Copy traits for column and row enums

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ const LED_REG_MAX: u8 = 0xC6;
 const NUM_LED_REG: usize = ((LED_REG_MAX - LED_REG_MIN) + 1) as usize;
 
 /// Switch column.
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub enum SWx {
     /// Switch column 1
     SW1,
@@ -105,6 +106,7 @@ impl TryFrom<u8> for SWx {
 }
 
 /// Current sink row.
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub enum CSy {
     /// Current sink row 1
     CS1,


### PR DESCRIPTION
Currently, the `Is31fl3743bDevice` methods that interact with the LEDs take in the column coordinate enum `SWx` and row coordinate enum `CSy` by value. For example: 
`driver.set_led_brightness(SWx::SW1, CSy::CS1, 100);`

While this works for single value literals of the switch and column enums, if we want to represent the LEDs as an array that we iterate over, the value will be consumed every time we call a method:

```
const COLS: [SWx; 11] = [SWx::SW1, SWx::SW2, SWx::SW3, SWx::SW4, SWx::SW5, SWx::SW6, SWx::SW7, SWx::SW8, SWx::SW9, SWx::SW10, SWx::SW11];
const ROWS: [CSy; 18] = [CSy::CS1, CSy::CS2, CSy::CS3, CSy::CS4, CSy::CS5, CSy::CS6, CSy::CS7, CSy::CS8, CSy::CS9, CSy::CS10, CSy::CS11, CSy::CS12, CSy::CS13, CSy::CS14, CSy::CS15, CSy::CS16, CSy::CS17, CSy::CS18];

for i in ROWS.into_iter() {
    for j in COLS.into_iter() {
        let _ = driver.set_led_brightness(j, i, 100).await;
        let row: u8 = u8::from(i);
        let col: u8 = u8::from(j);
        info!("Turning on LED from row {} col {}", row, col);
        Timer::after(Duration::from_millis(10)).await;
    }
}
```

To fix this issue, we derive `Copy` and `Clone` so we don't pass ownership into the driver's methods.