### PR TITLE
Fix cargo fmt error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! This is a platform-agnostic Rust driver for the Lumissil IS31FL3743B LED 
+//! This is a platform-agnostic Rust driver for the Lumissil IS31FL3743B LED
 //! Matrix Driver based on the [`embedded-hal`] traits.
 //!
 //! [`embedded-hal`]: https://docs.rs/embedded-hal


### PR DESCRIPTION
Removes a trailing whitespace causing cargo fmt CI failures.