### PR TITLE
Update LICENSE copyright and add AI attribution instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,20 @@
+# Copilot Instructions
+
+## Commit Messages
+- Subject line: capitalized, 50 characters or less, imperative mood (e.g., "Fix bug" not "Fixed bug")
+- Separate subject from body with a blank line
+- Wrap body text at 72 characters
+- Use the body to explain *what* and *why*, not *how*
+
+## AI Attribution
+Every commit that includes AI-generated or AI-assisted work **must** contain an `Assisted-by` trailer in the commit message:
+```
+Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
+```
+Where:
+- `AGENT_NAME` is the name of the AI tool or framework (e.g., `GitHub Copilot`)
+- `MODEL_VERSION` is the specific model version used (e.g., `claude-opus-4.6`)
+- `[TOOL1] [TOOL2]` are optional specialized analysis tools used (e.g., `coccinelle`, `sparse`, `smatch`, `clang-tidy`)
+Basic development tools (git, cargo, editors) should not be listed.
+AI agents **must** verify their own identity (agent name and model version) before composing the `Assisted-by` trailer — do not assume or hard-code a model name from a previous session.
+AI agents **MUST NOT** add `Signed-off-by` tags. Only humans can certify the Developer Certificate of Origin.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Open Device Partnership
+Copyright (c) Open Device Partnership and Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This PR applies two org-wide standardisation changes
(ref: OpenDevicePartnership/embedded-rust-template#20):

1. **LICENSE** – normalise the copyright line to:
   `Copyright (c) Open Device Partnership and Contributors`

2. **.github/copilot-instructions.md** – add the *Commit Messages* and
   *AI Attribution* sections so every repo carries consistent guidance
   for contributors and AI agents.
